### PR TITLE
Auto-detect xr_usb id

### DIFF
--- a/udev_rules/README.md
+++ b/udev_rules/README.md
@@ -1,13 +1,7 @@
 # udev setup for Oille with other cdc_acm devices
 
 ## udev
-Place the file `ollie.rules` into  the directory `/etc/udev/rules.d/`
+Place the file `ollie.rules` into the directory `/etc/udev/rules.d/`
 
 ## Helper script
-Place the helper script `ollie-plug.sh` into `/usr/local/bin/`
-
-
-### Notes
-Vendor ID: 0424   
-Model ID: 2514   
-Is the root hub USB device of the Olle, this allows us to detect when its plugged in and take action
+Place the helper script `ollie-plug.sh` into `/usr/local/bin/`. The above udev rule calls this script.

--- a/udev_rules/ollie-plug.sh
+++ b/udev_rules/ollie-plug.sh
@@ -1,25 +1,41 @@
 #!/bin/bash
 
-# 3-1.2:1.X is each UART on Ollie.
-#EG:
-# cdc_xr_usb_serial 3-1.2:1.0: USB_device_id idVendor:04e2, idProduct 1414
-# cdc_xr_usb_serial 3-1.2:1.0: ttyXR_USB_SERIAL0: USB XR_USB_SERIAL device
-# cdc_xr_usb_serial 3-1.2:1.2: USB_device_id idVendor:04e2, idProduct 1414
-# cdc_xr_usb_serial 3-1.2:1.2: ttyXR_USB_SERIAL1: USB XR_USB_SERIAL device
-# cdc_xr_usb_serial 3-1.2:1.4: USB_device_id idVendor:04e2, idProduct 1414
-# cdc_xr_usb_serial 3-1.2:1.4: ttyXR_USB_SERIAL2: USB XR_USB_SERIAL device
-# cdc_xr_usb_serial 3-1.2:1.6: USB_device_id idVendor:04e2, idProduct 1414
-# cdc_xr_usb_serial 3-1.2:1.6: ttyXR_USB_SERIAL3: USB XR_USB_SERIAL device
+# USB id is in the format of:
+#   bus-port.port.port ... port:config.interface
+#   http://www.linux-usb.org/FAQ.html#i6
+
+# This script extracts the usb id from the DEVPATH environment
+# variable, which is passed to this script via set by udev rules.
+# Here are some more tips on how to find which environment
+# variables are available:
+#  https://stackoverflow.com/a/12819134
+
+# For debugging scripts called by udev:
+#   sudo udevadm control --log-priority=debug
+#   journalctl -f
+# You can add prints/echo to this script (viewable in journalctl)
+# and/or log to a file
+
+# To get more information about device attributes for udev matching:
+#   Before this script is run (with acm driver):
+#     udevadm info -a /dev/ttyACM0
+#   After this script is run (with xr_usb driver):
+#     udevadm info -a /dev/ttyXRUSB0
+
+# As a sanity check for usb ID when replugging ollie:
+#  dmesg -Hw
+
+my_usb_id=$(basename $DEVPATH)
 
 # Unbind kernel module cdc_acm module
-echo "3-1.2:1.0" > /sys/bus/usb/drivers/cdc_acm/unbind
-echo "3-1.2:1.2" > /sys/bus/usb/drivers/cdc_acm/unbind
-echo "3-1.2:1.4" > /sys/bus/usb/drivers/cdc_acm/unbind
-echo "3-1.2:1.6" > /sys/bus/usb/drivers/cdc_acm/unbind
+echo "$my_usb_id:1.0" > /sys/bus/usb/drivers/cdc_acm/unbind
+echo "$my_usb_id:1.2" > /sys/bus/usb/drivers/cdc_acm/unbind
+echo "$my_usb_id:1.4" > /sys/bus/usb/drivers/cdc_acm/unbind
+echo "$my_usb_id:1.6" > /sys/bus/usb/drivers/cdc_acm/unbind
 
 # Bind cdc_xr_usb_serial module
-echo "3-1.2:1.0" > /sys/bus/usb/drivers/cdc_xr_usb_serial/bind
-echo "3-1.2:1.2" > /sys/bus/usb/drivers/cdc_xr_usb_serial/bind
-echo "3-1.2:1.4" > /sys/bus/usb/drivers/cdc_xr_usb_serial/bind
-echo "3-1.2:1.6" > /sys/bus/usb/drivers/cdc_xr_usb_serial/bind
+echo "$my_usb_id:1.0" > /sys/bus/usb/drivers/cdc_xr_usb_serial/bind
+echo "$my_usb_id:1.2" > /sys/bus/usb/drivers/cdc_xr_usb_serial/bind
+echo "$my_usb_id:1.4" > /sys/bus/usb/drivers/cdc_xr_usb_serial/bind
+echo "$my_usb_id:1.6" > /sys/bus/usb/drivers/cdc_xr_usb_serial/bind
 

--- a/udev_rules/ollie.rules
+++ b/udev_rules/ollie.rules
@@ -1,1 +1,9 @@
-SUBSYSTEM=="usb", ACTION=="add", ENV{ID_VENDOR_ID}=="0424", ENV{ID_MODEL_ID}=="2514", RUN+="/usr/local/bin/ollie-plug.sh"
+# Match Exar 4-channel UART IC
+# https://www.maxlinear.com/product/interface/uarts/usb-uarts/xr21v1414
+#
+# See the following datasheet sections:
+#   1.1.1 USB Vendor ID
+#     "Exar’s USB Vendor ID is 0x04E2."
+#   1.1.2 USB Product ID
+#     "The default USB Product ID for the V1414 is 0x1414."
+SUBSYSTEM=="usb", ACTION=="add", ENV{ID_VENDOR_ID}=="04e2", ENV{ID_MODEL_ID}=="1414", RUN+="/usr/local/bin/ollie-plug.sh"


### PR DESCRIPTION
The previous script used a hardcoded USB ID of `3-1.2` which is port-specific (and doesn't actually match any port on a pi 4).

This script matches against the Exar vendor+product IDs and automatically determines the correct USB ID. Now you can plug into any USB port and the correct drivers will load.